### PR TITLE
Fix: Add glob function to determine changed pom.xml files for snapshot version update

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "@semantic-release/error": "^3.0.0",
     "@semantic-release/git": "^10.0.1",
-    "execa": "^5.1.1"
+    "execa": "^5.1.1",
+    "glob": "^9.2.1"
   },
   "devDependencies": {
     "release-it": "^15.5.1"

--- a/src/success.js
+++ b/src/success.js
@@ -6,7 +6,9 @@ const {
     add,
     commit,
     push
-} = require('@semantic-release/git/lib/git')
+} = require('@semantic-release/git/lib/git');
+
+const glob = require("glob");
 
 module.exports = async function success(pluginConfig, {
     logger,
@@ -19,11 +21,13 @@ module.exports = async function success(pluginConfig, {
     const snapshotCommitMessage = pluginConfig.snapshotCommitMessage || 'chore: setting next snapshot version [skip ci]';
     const processAllModules = pluginConfig.processAllModules || false;
 
+    const filesToCommit = await glob('**/pom.xml', { ignore: 'node_modules/**' });
+
     if (updateSnapshotVersionOpt) {
         await updateSnapshotVersion(logger, processAllModules);
         const execaOptions = { env, cwd };
-        logger.log('Staging all changed pom.xml');
-        await add(['pom.xml', '**/pom.xml'], execaOptions);
+        logger.log('Staging all changed files: ' + filesToCommit.join(", "));
+        await add(filesToCommit, execaOptions);
         logger.log('Committing all changed pom.xml');
         await commit(snapshotCommitMessage, execaOptions);
         logger.log('Pushing commit');


### PR DESCRIPTION
This PR adds a fix for the `success.js` process updating the maven snapshot version for cases where only one `pom.xml` file is present in the project.

The previous call of 
```javascript
await add(['pom.xml', '**/pom.xml'], execaOptions);
```
led to a git error, complaining that the pathspec was not found (`"fatal: pathspec '**/pom.xml' did not match any files"`).

Therefore, this PR implements a fix for this by scanning for all available `pom.xml` files and only pass them to the git-add command.