### PR TITLE
fix: failure with updateSnapshotVersion=true with pom.xml in root of the project

### DIFF
--- a/src/success.js
+++ b/src/success.js
@@ -21,7 +21,7 @@ module.exports = async function success(pluginConfig, {
     const snapshotCommitMessage = pluginConfig.snapshotCommitMessage || 'chore: setting next snapshot version [skip ci]';
     const processAllModules = pluginConfig.processAllModules || false;
 
-    const filesToCommit = await glob('**/pom.xml', { ignore: 'node_modules/**' });
+    const filesToCommit = await glob('pom.xml', '**/pom.xml', { ignore: 'node_modules/**' });
 
     if (updateSnapshotVersionOpt) {
         const settingsPath = pluginConfig.settingsPath || '.m2/settings.xml';


### PR DESCRIPTION
Looks like this was introduced with #10 where pom.xml in the root of the project are no longer considered as a part of the glob.