### PR TITLE
fix: use home instead of cwd as settingsPath

### DIFF
--- a/src/plugin-config.js
+++ b/src/plugin-config.js
@@ -1,6 +1,6 @@
 /**
  * @typedef {Object} PluginConfig
- * @property {string} [settingsPath='.m2/settings.xml'] Path to a maven settings file.
+ * @property {string} [settingsPath='~/.m2/settings.xml'] Path to a maven settings file.
  * @property {boolean} [processAllModules=false] This sets the `processAllModules` option for the `versions:set` target. It is useful for multimodule projects.
  * @property {'deploy'|'package jib:build'|'deploy jib:build'} [mavenTarget='deploy'] This determines which mvn targets are used to publish.
  * @property {boolean} [clean=true] Whether the `clean` target will be applied before publishing.

--- a/src/prepare.js
+++ b/src/prepare.js
@@ -14,7 +14,7 @@ module.exports = async function prepare(pluginConfig, {
 }) {
     logger.log('prepare maven release');
 
-    const settingsPath = pluginConfig.settingsPath || '.m2/settings.xml';
+    const settingsPath = pluginConfig.settingsPath || '~/.m2/settings.xml';
 
     if (!/^[\w~./-]*$/.test(settingsPath)) {
         throw new Error('config settingsPath contains disallowed characters');

--- a/src/publish.js
+++ b/src/publish.js
@@ -14,7 +14,7 @@ module.exports = async function publish(pluginConfig, {
 }) {
     logger.log('publish mvn release');
 
-    const settingsPath = pluginConfig.settingsPath || '.m2/settings.xml';
+    const settingsPath = pluginConfig.settingsPath || '~/.m2/settings.xml';
     const mavenTarget = pluginConfig.mavenTarget || 'deploy';
     const clean = pluginConfig.clean || true;
     const debug = pluginConfig.debug || false;

--- a/src/success.js
+++ b/src/success.js
@@ -37,7 +37,7 @@ module.exports = async function success(pluginConfig, {
     });
 
     if (updateSnapshotVersionOpt) {
-        const settingsPath = pluginConfig.settingsPath || '.m2/settings.xml';
+        const settingsPath = pluginConfig.settingsPath || '~/.m2/settings.xml';
 
         if (!/^[\w~./-]*$/.test(settingsPath)) {
             throw new Error('config settingsPath contains disallowed characters');


### PR DESCRIPTION
action/setup-java creates a default file there

BREAKING CHANGE: The default for the `settingsPath` changes from `.m2/settings.xml` to `~/.m2/settings.xml`. This is the same path that `action/setup-java` uses by default.