### PR TITLE
fix: removing default for maven settings and only set it if provided by user

### DIFF
--- a/src/maven.js
+++ b/src/maven.js
@@ -7,9 +7,24 @@ const SemanticReleaseError = require("@semantic-release/error");
 const { exec } = require('./exec');
 
 /**
+ * @param {string|undefined} settingsPath
+ * @returns {string[]}
+ */
+function settingsOption(settingsPath) {
+    if (settingsPath) {
+        return [
+            '--settings',
+            settingsPath
+        ];
+    } else {
+        return [];
+    }
+}
+
+/**
  * @param {Logger} logger
  * @param {string} versionStr
- * @param {string} settingsPath
+ * @param {string|undefined} settingsPath
  * @param {boolean} processAllModules
  * @param {boolean} debug
  * @returns {Promise<void>}
@@ -28,8 +43,7 @@ async function updateVersion(logger, versionStr, settingsPath, processAllModules
             '--batch-mode',
             '--no-transfer-progress',
             '-DgenerateBackupPoms=false',
-            '--settings',
-            settingsPath,
+            ...settingsOption(settingsPath),
             `-DnewVersion=${versionStr}`,
             ...processAllModulesOption
         ]
@@ -38,7 +52,7 @@ async function updateVersion(logger, versionStr, settingsPath, processAllModules
 
 /**
  * @param {Logger} logger
- * @param {string} settingsPath
+ * @param {string|undefined} settingsPath
  * @param {boolean} processAllModules
  * @param {boolean} debug
  * @returns {Promise<void>}
@@ -57,8 +71,7 @@ async function updateSnapshotVersion(logger, settingsPath, processAllModules, de
             '--batch-mode',
             '--no-transfer-progress',
             '-DnextSnapshot=true',
-            '--settings',
-            settingsPath,
+            ...settingsOption(settingsPath),
             '-DgenerateBackupPoms=false',
             ...processAllModulesOption
         ]
@@ -69,7 +82,7 @@ async function updateSnapshotVersion(logger, settingsPath, processAllModules, de
  * @param {Logger} logger
  * @param {string} nextVersion
  * @param {string} mavenTarget
- * @param {string} settingsPath
+ * @param {string|undefined} settingsPath
  * @param {boolean} clean
  * @param {boolean} debug
  * @returns {Promise<void>}
@@ -90,8 +103,7 @@ async function deploy(logger, nextVersion, mavenTarget, settingsPath, clean, deb
               '--batch-mode',
               '--no-transfer-progress',
               '-DskipTests',
-              '--settings',
-              settingsPath
+              ...settingsOption(settingsPath)
           ]
         );
     } catch (e) {

--- a/src/plugin-config.js
+++ b/src/plugin-config.js
@@ -1,6 +1,6 @@
 /**
  * @typedef {Object} PluginConfig
- * @property {string} [settingsPath='~/.m2/settings.xml'] Path to a maven settings file.
+ * @property {string} [settingsPath] Path to a maven settings file.
  * @property {boolean} [processAllModules=false] This sets the `processAllModules` option for the `versions:set` target. It is useful for multimodule projects.
  * @property {'deploy'|'package jib:build'|'deploy jib:build'} [mavenTarget='deploy'] This determines which mvn targets are used to publish.
  * @property {boolean} [clean=true] Whether the `clean` target will be applied before publishing.
@@ -8,3 +8,39 @@
  * @property {string} [snapshotCommitMessage='chore: setting next snapshot version [skip ci]'] The commit message used if a new snapshot version should be created.
  * @property {boolean} [debug=false] Sets the `-X` option for all maven calls.
  */
+
+/**
+ * @param {Partial<PluginConfig>} config
+ * @returns {PluginConfig}
+ */
+function evaluateConfig(config) {
+    const withDefaults = Object.assign({
+        processAllModules: false,
+        mavenTarget: 'deploy',
+        clean: true,
+        updateSnapshotVersion: false,
+        snapshotCommitMessage: 'chore: setting next snapshot version [skip ci]',
+        debug: false
+    }, config);
+
+    if (!/^[\w~./-]*$/.test(withDefaults.settingsPath)) {
+        throw new Error('config settingsPath contains disallowed characters');
+    }
+
+    const availableTargets = [
+        'deploy',
+        'package jib:build',
+        'deploy jib:build'
+    ];
+
+    if (!availableTargets.includes(withDefaults.mavenTarget)) {
+        throw new Error(`unrecognized maven target ${withDefaults.mavenTarget}`);
+    }
+
+    return withDefaults;
+}
+
+module.exports = {
+    evaluateConfig
+};
+

--- a/src/prepare.js
+++ b/src/prepare.js
@@ -2,6 +2,10 @@ const {
     updateVersion
 } = require("./maven");
 
+const {
+    evaluateConfig
+} = require('./plugin-config');
+
 /**
  * @param {PluginConfig} pluginConfig
  * @param {Logger} logger
@@ -14,14 +18,11 @@ module.exports = async function prepare(pluginConfig, {
 }) {
     logger.log('prepare maven release');
 
-    const settingsPath = pluginConfig.settingsPath || '~/.m2/settings.xml';
-
-    if (!/^[\w~./-]*$/.test(settingsPath)) {
-        throw new Error('config settingsPath contains disallowed characters');
-    }
-
-    const processAllModules = pluginConfig.processAllModules || false;
-    const debug = pluginConfig.debug || false;
+    const {
+        settingsPath,
+        processAllModules,
+        debug
+    } = evaluateConfig(pluginConfig);
 
     await updateVersion(logger, nextRelease.version, settingsPath, processAllModules, debug);
 };

--- a/src/publish.js
+++ b/src/publish.js
@@ -2,6 +2,10 @@ const {
     deploy
 } = require("./maven");
 
+const {
+    evaluateConfig
+} = require('./plugin-config');
+
 /**
  * @param {PluginConfig} pluginConfig
  * @param {Logger} logger
@@ -14,24 +18,12 @@ module.exports = async function publish(pluginConfig, {
 }) {
     logger.log('publish mvn release');
 
-    const settingsPath = pluginConfig.settingsPath || '~/.m2/settings.xml';
-    const mavenTarget = pluginConfig.mavenTarget || 'deploy';
-    const clean = pluginConfig.clean !== false;
-    const debug = pluginConfig.debug === true;
-
-    if (!/^[\w~./-]*$/.test(settingsPath)) {
-        throw new Error('config settingsPath contains disallowed characters');
-    }
-
-    const availableTargets = [
-        'deploy',
-        'package jib:build',
-        'deploy jib:build'
-    ];
-
-    if (!availableTargets.includes(mavenTarget)) {
-        throw new Error(`unrecognized maven target ${mavenTarget}`);
-    }
+    const {
+        settingsPath,
+        mavenTarget,
+        clean,
+        debug
+    } = evaluateConfig(pluginConfig);
 
     await deploy(logger, nextRelease.version, mavenTarget, settingsPath, clean, debug);
 };

--- a/src/success.js
+++ b/src/success.js
@@ -3,6 +3,10 @@ const {
 } = require("./maven");
 
 const {
+    evaluateConfig
+} = require('./plugin-config');
+
+const {
     add,
     commit,
     push
@@ -26,10 +30,13 @@ module.exports = async function success(pluginConfig, {
     branch,
     options: { repositoryUrl }
 }) {
-    const updateSnapshotVersionOpt = pluginConfig.updateSnapshotVersion || false;
-    const snapshotCommitMessage = pluginConfig.snapshotCommitMessage || 'chore: setting next snapshot version [skip ci]';
-    const processAllModules = pluginConfig.processAllModules || false;
-    const debug = pluginConfig.debug || false;
+    const {
+        updateSnapshotVersion: updateSnapshotVersionOpt,
+        snapshotCommitMessage,
+        processAllModules,
+        debug,
+        settingsPath
+    } = evaluateConfig(pluginConfig)
 
     const filesToCommit = await glob('**/pom.xml', {
         cwd,
@@ -37,11 +44,6 @@ module.exports = async function success(pluginConfig, {
     });
 
     if (updateSnapshotVersionOpt) {
-        const settingsPath = pluginConfig.settingsPath || '~/.m2/settings.xml';
-
-        if (!/^[\w~./-]*$/.test(settingsPath)) {
-            throw new Error('config settingsPath contains disallowed characters');
-        }
         await updateSnapshotVersion(logger, settingsPath, processAllModules, debug);
         const execaOptions = { env, cwd };
         logger.log('Staging all changed files: ' + filesToCommit.join(", "));


### PR DESCRIPTION
See #37 for details.

This also contains a function to process the config. It validates certain options at a central point and assigns all default values.